### PR TITLE
Fix Cargo.toml bin section and syntax in main.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[[bin]]
+name = "rust-command-line-todo-list"
+path = "main.rs"

--- a/main.rs
+++ b/main.rs
@@ -56,6 +56,7 @@ impl Todo {
             .open("db.txt")?;
 
         file.write_all(content.as_bytes())?;
+        Ok(())
     }
 
     // Mark an item as complete
@@ -93,7 +94,7 @@ fn main() {
   }
 
   let action = &args[1];
-  let item = if args.len()>2 { Some{&args[2]} } else { None };
+  let item = if args.len()>2 { Some(&args[2]) } else { None };
 
   let mut todo = Todo::new().expect("Initialization of db failed");
 


### PR DESCRIPTION
Correct the bin section in Cargo.toml and fix syntax errors in main.rs to ensure proper functionality.